### PR TITLE
Fix metadata export for register page

### DIFF
--- a/src/app/(auth)/register/RegisterForm.tsx
+++ b/src/app/(auth)/register/RegisterForm.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import type { FormEvent } from 'react'
+
+import { Button } from '@/components/Button'
+import { SelectField, TextField } from '@/components/Fields'
+
+export function RegisterForm() {
+  const router = useRouter()
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+
+    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(Object.fromEntries(formData)),
+    })
+
+    router.push('/login')
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2"
+    >
+      <TextField
+        label="First name"
+        name="first_name"
+        type="text"
+        autoComplete="given-name"
+        required
+      />
+      <TextField
+        label="Last name"
+        name="last_name"
+        type="text"
+        autoComplete="family-name"
+        required
+      />
+      <TextField
+        className="col-span-full"
+        label="Email address"
+        name="email"
+        type="email"
+        autoComplete="email"
+        required
+      />
+      <TextField
+        className="col-span-full"
+        label="Password"
+        name="password"
+        type="password"
+        autoComplete="new-password"
+        required
+      />
+      <SelectField
+        className="col-span-full"
+        label="How did you hear about us?"
+        name="referral_source"
+      >
+        <option>AltaVista search</option>
+        <option>Super Bowl commercial</option>
+        <option>Our route 34 city bus ad</option>
+        <option>The “Never Use This” podcast</option>
+      </SelectField>
+      <div className="col-span-full">
+        <Button type="submit" variant="solid" color="blue" className="w-full">
+          <span>
+            Sign up <span aria-hidden="true">&rarr;</span>
+          </span>
+        </Button>
+      </div>
+    </form>
+  )
+}
+

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,35 +1,15 @@
-'use client'
-
 import { type Metadata } from 'next'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import type { FormEvent } from 'react'
 
-import { Button } from '@/components/Button'
-import { SelectField, TextField } from '@/components/Fields'
 import { Logo } from '@/components/Logo'
 import { SlimLayout } from '@/components/SlimLayout'
+import { RegisterForm } from './RegisterForm'
 
 export const metadata: Metadata = {
   title: 'Sign Up',
 }
 
 export default function Register() {
-  const router = useRouter()
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(Object.fromEntries(formData)),
-    })
-
-    router.push('/login')
-  }
-
   return (
     <SlimLayout>
       <div className="flex">
@@ -42,66 +22,12 @@ export default function Register() {
       </h2>
       <p className="mt-2 text-sm text-gray-700">
         Already registered?{' '}
-        <Link
-          href="/login"
-          className="font-medium text-blue-600 hover:underline"
-        >
+        <Link href="/login" className="font-medium text-blue-600 hover:underline">
           Sign in
         </Link>{' '}
         to your account.
       </p>
-      <form
-        onSubmit={handleSubmit}
-        className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2"
-      >
-        <TextField
-          label="First name"
-          name="first_name"
-          type="text"
-          autoComplete="given-name"
-          required
-        />
-        <TextField
-          label="Last name"
-          name="last_name"
-          type="text"
-          autoComplete="family-name"
-          required
-        />
-        <TextField
-          className="col-span-full"
-          label="Email address"
-          name="email"
-          type="email"
-          autoComplete="email"
-          required
-        />
-        <TextField
-          className="col-span-full"
-          label="Password"
-          name="password"
-          type="password"
-          autoComplete="new-password"
-          required
-        />
-        <SelectField
-          className="col-span-full"
-          label="How did you hear about us?"
-          name="referral_source"
-        >
-          <option>AltaVista search</option>
-          <option>Super Bowl commercial</option>
-          <option>Our route 34 city bus ad</option>
-          <option>The “Never Use This” podcast</option>
-        </SelectField>
-        <div className="col-span-full">
-          <Button type="submit" variant="solid" color="blue" className="w-full">
-            <span>
-              Sign up <span aria-hidden="true">&rarr;</span>
-            </span>
-          </Button>
-        </div>
-      </form>
+      <RegisterForm />
     </SlimLayout>
   )
 }


### PR DESCRIPTION
## Summary
- fix 'metadata' export error in register page by splitting client code
- create `RegisterForm` component for client-only logic

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684862cb7000833093265230a36feaa8