### PR TITLE
Fix login and register requests

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -29,6 +29,31 @@ app.post('/api/register', async (req, res) => {
   }
 })
 
+app.post('/api/login', async (req, res) => {
+  const { email, password } = req.body
+  try {
+    const result = await pool.query(
+      'SELECT password FROM users WHERE email = $1',
+      [email],
+    )
+    if (result.rowCount === 0) {
+      return res
+        .status(401)
+        .json({ success: false, message: 'Invalid credentials' })
+    }
+    const valid = await bcrypt.compare(password, result.rows[0].password)
+    if (!valid) {
+      return res
+        .status(401)
+        .json({ success: false, message: 'Invalid credentials' })
+    }
+    res.json({ success: true })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ success: false })
+  }
+})
+
 const PORT = process.env.PORT || 4000
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`)

--- a/src/app/(auth)/login/LoginForm.tsx
+++ b/src/app/(auth)/login/LoginForm.tsx
@@ -26,8 +26,7 @@ export function LoginForm() {
       if (res.ok) {
         router.push('/')
       } else {
-        const data = (await res.json()) as { message?: string }
-        setError(data.message || 'Wrong password')
+        setError('Wrong password')
       }
     } catch (err) {
       setError('Something went wrong')

--- a/src/app/(auth)/login/LoginForm.tsx
+++ b/src/app/(auth)/login/LoginForm.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import type { FormEvent } from 'react'
+import { useState } from 'react'
+
+import { Button } from '@/components/Button'
+import { TextField } from '@/components/Fields'
+
+export function LoginForm() {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+
+    try {
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+      const res = await fetch(`${baseUrl}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(Object.fromEntries(formData)),
+      })
+
+      if (res.ok) {
+        router.push('/')
+      } else {
+        const data = (await res.json()) as { message?: string }
+        setError(data.message || 'Wrong password')
+      }
+    } catch (err) {
+      setError('Something went wrong')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-10 grid grid-cols-1 gap-y-8">
+      <TextField
+        label="Email address"
+        name="email"
+        type="email"
+        autoComplete="email"
+        required
+      />
+      <TextField
+        label="Password"
+        name="password"
+        type="password"
+        autoComplete="current-password"
+        required
+      />
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <div>
+        <Button type="submit" variant="solid" color="blue" className="w-full">
+          <span>
+            Sign in <span aria-hidden="true">&rarr;</span>
+          </span>
+        </Button>
+      </div>
+    </form>
+  )
+}
+

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,8 +1,7 @@
 import { type Metadata } from 'next'
 import Link from 'next/link'
 
-import { Button } from '@/components/Button'
-import { TextField } from '@/components/Fields'
+import { LoginForm } from './LoginForm'
 import { Logo } from '@/components/Logo'
 import { SlimLayout } from '@/components/SlimLayout'
 
@@ -31,29 +30,7 @@ export default function Login() {
         </Link>{' '}
         for a free trial.
       </p>
-      <form action="#" className="mt-10 grid grid-cols-1 gap-y-8">
-        <TextField
-          label="Email address"
-          name="email"
-          type="email"
-          autoComplete="email"
-          required
-        />
-        <TextField
-          label="Password"
-          name="password"
-          type="password"
-          autoComplete="current-password"
-          required
-        />
-        <div>
-          <Button type="submit" variant="solid" color="blue" className="w-full">
-            <span>
-              Sign in <span aria-hidden="true">&rarr;</span>
-            </span>
-          </Button>
-        </div>
-      </form>
+      <LoginForm />
     </SlimLayout>
   )
 }

--- a/src/app/(auth)/register/RegisterForm.tsx
+++ b/src/app/(auth)/register/RegisterForm.tsx
@@ -13,7 +13,8 @@ export function RegisterForm() {
     event.preventDefault()
     const formData = new FormData(event.currentTarget)
 
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/register`, {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+    await fetch(`${baseUrl}/api/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(Object.fromEntries(formData)),


### PR DESCRIPTION
## Summary
- handle missing `NEXT_PUBLIC_API_URL` gracefully in Login and Register forms
- surface API error messages when login fails

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684864a9e9648330a5a2cbd2e84d2751